### PR TITLE
Add 8-bit support on CPU

### DIFF
--- a/awq/utils/lm_eval_adaptor.py
+++ b/awq/utils/lm_eval_adaptor.py
@@ -65,7 +65,8 @@ class LMEvalAdaptor(BaseLM):
 
     @property
     def device(self):
-        return "cuda"
+        #return "cuda"
+        return "cpu"
 
     def tok_encode(self, string: str):
         return self.tokenizer.encode(string, add_special_tokens=False)


### PR DESCRIPTION
awq 8bit steps:
1. run awq search to get scales and zeros 
```python
python -m awq.entry --model_path <path/to/Llama-2-7b-hf>  --w_bit 8 --q_group_size 128  --run_awq --dump_awq awq_cache/llama2_7b_w8.pt
```

2. use fake quantization to get perplexity on wikitextv1 
```python
python -m awq.entry --model_path <path/to/Llama-2-7b-hf>  --tasks wikitext --w_bit 8 --q_group_size 128  --load_awq awq_cache/llama2_7b_w8.pt  --q_backend fake
```

3. dump real quantization weights 
```python
python -m awq.entry --model_path <path/to/Llama-2-7b-hf>  --w_bit 8 --q_group_size 128  --load_awq awq_cache/llama2_7b_w8.pt --q_backend real --dump_quant quant_cache/llama2_7b_w8-g128-awq.pt
```

4. [TBD] load llama2_7b_w8-g128-awq.pt in xFT.